### PR TITLE
Add BS reliability web app

### DIFF
--- a/bs_app/app.py
+++ b/bs_app/app.py
@@ -1,0 +1,84 @@
+import os
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+
+app = FastAPI()
+
+BASE_DIR = os.path.dirname(__file__)
+INDEX_PATH = os.path.join(BASE_DIR, "templates", "index.html")
+
+# Utility functions
+
+def parse_matrix(text: str):
+    lines = text.strip().splitlines()
+    matrix = []
+    for line in lines:
+        row = [float(x) for x in line.split(',')]
+        matrix.append(row)
+    return matrix
+
+def multiply_vector_matrix(vector, matrix):
+    result = []
+    for j in range(len(matrix[0])):
+        s = 0.0
+        for i in range(len(vector)):
+            s += vector[i] * matrix[i][j]
+        result.append(s)
+    return result
+
+def steady_state(matrix, tolerance=1e-6, max_iter=1000):
+    # simple power iteration
+    n = len(matrix)
+    prob = [1.0 / n] * n
+    for _ in range(max_iter):
+        new_prob = multiply_vector_matrix(prob, matrix)
+        diff = sum(abs(a - b) for a, b in zip(prob, new_prob))
+        prob = new_prob
+        if diff < tolerance:
+            break
+    return prob
+
+def monte_carlo(trials: int, steps: int):
+    import random
+
+    up_prob = []
+    for _ in range(trials):
+        state = 0  # 0: up, 1: down waiting, 2: repair
+        up_time = 0
+        for _ in range(steps):
+            r = random.random()
+            if state == 0:
+                state = 0 if r < 0.98 else 1
+            elif state == 1:
+                state = 2
+            else:  # state==2
+                state = 0 if r < 0.95 else 2
+            if state == 0:
+                up_time += 1
+        up_prob.append(up_time / steps)
+    return sum(up_prob) / trials
+
+@app.get("/", response_class=HTMLResponse)
+def read_index():
+    with open(INDEX_PATH, "r", encoding="utf-8") as f:
+        return f.read()
+
+@app.get("/markov", response_class=HTMLResponse)
+def markov(matrix: str):
+    m = parse_matrix(matrix)
+    probs = steady_state(m)
+    availability = probs[0]
+    html = f"<h2>Markov结果</h2><p>稳态概率: {probs}</p><p>系统可用度: {availability:.4f}</p><a href='/'>&larr; 返回</a>"
+    return html
+
+@app.get("/montecarlo", response_class=HTMLResponse)
+def monte_carlo_route(trials: int, steps: int):
+    availability = monte_carlo(trials, steps)
+    html = f"<h2>蒙特卡罗仿真结果</h2><p>平均可用度: {availability:.4f}</p><a href='/'>&larr; 返回</a>"
+    return html
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8001)
+

--- a/bs_app/templates/index.html
+++ b/bs_app/templates/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>可靠性建模仿真平台</title>
+</head>
+<body>
+    <h1>可靠性建模仿真平台</h1>
+    <h2>Markov模型计算</h2>
+    <form action="/markov" method="get">
+        <p>请输入3x3状态转移矩阵，每行用逗号分隔:</p>
+        <textarea name="matrix" rows="3" cols="30">0.98,0.02,0
+0,0,1
+0.95,0,0.05</textarea>
+        <br>
+        <button type="submit">计算</button>
+    </form>
+    <h2>蒙特卡罗仿真</h2>
+    <form action="/montecarlo" method="get">
+        <p>仿真次数: <input type="number" name="trials" value="1000"></p>
+        <p>仿真时间步长: <input type="number" name="steps" value="100"></p>
+        <button type="submit">开始仿真</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple FastAPI-based web app under `bs_app`
- implement Markov and Monte Carlo reliability calculations
- include a minimal HTML form for user input

## Testing
- `pytest -q`
- `curl http://localhost:8001`
- `curl http://localhost:8001/markov?matrix=0.98,0.02,0%0A0,0,1%0A0.95,0,0.05`
- `curl http://localhost:8001/montecarlo?trials=100&steps=100`
