### PR TITLE
Add basic MySQL-driven visualization dashboard

### DIFF
--- a/DataVizDashboard/README.md
+++ b/DataVizDashboard/README.md
@@ -1,0 +1,27 @@
+# Data Visualization Dashboard
+
+This directory provides a minimal browser/server (B/S) application that connects to a MySQL database and displays data on a web page using Chart.js. It is intended as a starting point for building a large-screen data visualization system.
+
+## Features
+
+- Connects to MySQL using environment variables:
+  - `MYSQL_HOST` (default `localhost`)
+  - `MYSQL_USER` (default `root`)
+  - `MYSQL_PASSWORD` (default empty)
+  - `MYSQL_DB` (default `test`)
+  - `MYSQL_TABLE` (default `sample_data`)
+- Fetches `label` and `value` columns from the configured table and displays them using a selectable chart type (bar, line, or pie).
+- Uses Flask for the backend and Chart.js on the frontend.
+
+## Running
+
+Install the requirements and start the server:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Ensure the environment variables for your MySQL database are set before running the server. Then open `http://localhost:5000/` in a browser to view the dashboard.
+
+This example is deliberately simple and can be extended for more complex visualization needs.

--- a/DataVizDashboard/app.py
+++ b/DataVizDashboard/app.py
@@ -1,0 +1,36 @@
+from flask import Flask, render_template, jsonify
+import pymysql
+import os
+
+app = Flask(__name__)
+
+def get_db_connection():
+    return pymysql.connect(
+        host=os.environ.get('MYSQL_HOST', 'localhost'),
+        user=os.environ.get('MYSQL_USER', 'root'),
+        password=os.environ.get('MYSQL_PASSWORD', ''),
+        db=os.environ.get('MYSQL_DB', 'test'),
+        charset='utf8mb4',
+        cursorclass=pymysql.cursors.DictCursor
+    )
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/data')
+def data():
+    table = os.environ.get('MYSQL_TABLE', 'sample_data')
+    conn = get_db_connection()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(f"SELECT label, value FROM {table} LIMIT 100")
+            rows = cursor.fetchall()
+    finally:
+        conn.close()
+    labels = [row['label'] for row in rows]
+    values = [row['value'] for row in rows]
+    return jsonify({'labels': labels, 'values': values})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/DataVizDashboard/requirements.txt
+++ b/DataVizDashboard/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+pymysql

--- a/DataVizDashboard/templates/index.html
+++ b/DataVizDashboard/templates/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Data Visualization Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body>
+<div class="container mt-4">
+    <h1>Data Visualization Dashboard</h1>
+    <div class="mb-3">
+        <label for="chartType" class="form-label">Chart Type</label>
+        <select id="chartType" class="form-select">
+            <option value="bar">Bar</option>
+            <option value="line">Line</option>
+            <option value="pie">Pie</option>
+        </select>
+    </div>
+    <canvas id="chart" height="80"></canvas>
+</div>
+<script>
+async function fetchData() {
+    const response = await fetch('/data');
+    return await response.json();
+}
+
+function renderChart(type, data) {
+    const ctx = document.getElementById('chart');
+    new Chart(ctx, {
+        type: type,
+        data: {
+            labels: data.labels,
+            datasets: [{
+                label: 'Values',
+                data: data.values,
+                backgroundColor: 'rgba(54, 162, 235, 0.2)',
+                borderColor: 'rgba(54, 162, 235, 1)',
+                borderWidth: 1
+            }]
+        }
+    });
+}
+
+async function updateChart() {
+    const type = document.getElementById('chartType').value;
+    const data = await fetchData();
+    renderChart(type, data);
+}
+
+document.getElementById('chartType').addEventListener('change', updateChart);
+window.onload = updateChart;
+</script>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ cd AndroidCalendarApp
 ```
 
 The resulting APK can be found under `app/build/outputs/apk/debug/`.
+
+## Data Visualization Dashboard
+
+The `DataVizDashboard` directory contains a small Flask-based web application that connects to a MySQL database and displays data using Chart.js. It serves as a simple example of a browser/server (B/S) big-screen visualization tool.
+
+```bash
+cd DataVizDashboard
+pip install -r requirements.txt
+python app.py
+```
+
+Configure the required MySQL environment variables as described in `DataVizDashboard/README.md` before launching the server.


### PR DESCRIPTION
## Summary
- create a `DataVizDashboard` folder with a Flask app
- add Chart.js frontend for selecting chart types
- document how to run the server
- reference the dashboard in the project README

## Testing
- `python3 -m py_compile DataVizDashboard/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68405d1e067c832cbce61eceb1464c9f